### PR TITLE
Mask pulseaudio append from Cogent and AGL layer

### DIFF
--- a/conf/include/agl_rcar_xt.inc
+++ b/conf/include/agl_rcar_xt.inc
@@ -56,6 +56,8 @@ BBMASK .= "|meta-rcar-gen3/recipes-bsp/alsa-state/alsa-state.bbappend"
 
 # Provide own pulseaudio configuration
 BBMASK .= "|meta-agl-devel/ATTIC/meta-audio-4a-framework/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend"
+BBMASK .= "|bsp/meta-rcar/meta-rcar-gen3-adas/recipes-multimedia/pulseaudio/pulseaudio_12_2.bbappend"
+BBMASK .= "|meta-agl/meta-agl-profile-core/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend"
 
 OSTREE_BOOTLOADER ?= "u-boot"
 BB_DANGLINGAPPENDS_WARNONLY = "yes"


### PR DESCRIPTION
Mask pulseaudio append from Cogent as we already have this recipe in
meta-xt-prod-extra layer. Mask AGL layer as it adds pulseaudio user service
but we've already added it as system service.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>