### PR TITLE
Remove connman from image

### DIFF
--- a/inc/agl-image.inc
+++ b/inc/agl-image.inc
@@ -37,6 +37,19 @@ DEPENDS += " u-boot"
 # So, we provide machine overrides from this build to Dom0
 EXTRA_IMAGEDEPENDS += " domd-install-machine-overrides"
 
+# We use systemd-networkd so we need to remove connman
+IMAGE_INSTALL_remove = " \
+    connman \
+    connman-client \
+    connman-tests \
+    connman-tools \
+    connman-ncurses \
+    connman-conf \
+    connman-gnome \
+    cluster-connman-conf \
+    libconnman-qt5_git \
+"
+
 # Do not support secure environment
 IMAGE_INSTALL_remove = " \
     optee-linuxdriver \

--- a/recipes-platform/packagegroups/packagegroup-agl-cluster-demo-platform.bbappend
+++ b/recipes-platform/packagegroups/packagegroup-agl-cluster-demo-platform.bbappend
@@ -1,5 +1,13 @@
 RDEPENDS_${PN}_remove = " \
+    connman \
+    connman-client \
+    connman-tests \
+    connman-tools \
+    connman-ncurses \
+    connman-conf \
+    connman-gnome \
     cluster-connman-conf \
+    libconnman-qt5_git \
     ${AGL_APPS} \
 "
 


### PR DESCRIPTION
We use systemd-networkd as network manager so we need to
remove connman in order to avoid conflicts.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>