### PR TITLE
Add Salvator-XS r8a7796 ES3.0+ with 8GiB (2 x 4 GiB) machine

### DIFF
--- a/conf/include/agl_salvator_xs_m3_2x4g_xt.inc
+++ b/conf/include/agl_salvator_xs_m3_2x4g_xt.inc
@@ -1,0 +1,4 @@
+SOC_FAMILY = "r8a7796"
+
+require agl_rcar_xt.inc
+

--- a/templates/machine/salvator-xs-m3-2x4g-xt/50_bblayers.conf.inc
+++ b/templates/machine/salvator-xs-m3-2x4g-xt/50_bblayers.conf.inc
@@ -1,0 +1,6 @@
+BBLAYERS =+ "\
+  ${METADIR}/bsp/meta-renesas-rcar-gen3/meta-rcar-gen3 \
+  ${METADIR}/bsp/meta-rcar/meta-rcar-gen3-adas \
+  ${METADIR}/meta-xt-images-rcar-gen3 \
+  ${METADIR}/meta-xt-agl-base \
+"

--- a/templates/machine/salvator-xs-m3-2x4g-xt/50_local.conf.inc
+++ b/templates/machine/salvator-xs-m3-2x4g-xt/50_local.conf.inc
@@ -1,0 +1,2 @@
+require conf/include/agl_salvator_xs_m3_2x4g_xt.inc
+


### PR DESCRIPTION
Add Renesas Salvator-XS 2nd version board based on r8a7796 ES3.0+
with 8GiB (2 x 4 GiB) machine.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>