### PR TITLE
gles-user-module: Install user files to localstatedir

### DIFF
--- a/recipes-graphics/gles-module/gles-user-module_%.bbappend
+++ b/recipes-graphics/gles-module/gles-user-module_%.bbappend
@@ -1,3 +1,10 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_append = " file://0001-Make-compiler-target-aarch64-agl-linux-be-recognized.patch"
+
+EXTRA_OEMAKE += "BIN_DESTDIR=${localstatedir}/local/bin"
+EXTRA_OEMAKE += "SHARE_DESTDIR=${localstatedir}/local/share"
+
+FILES_${PN}_append = "${localstatedir}/local/share/* \
+                      ${localstatedir}/local/bin/* \
+"


### PR DESCRIPTION
If not instructed gles-user-module tries to install user files into
/usr/local which is wrong in case of AGL which installs such files into
/var/local.
Fix this by properly configuring gles-user-module with this respect.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>
Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>