### PR TITLE
Add LAYERSERIES_COMPAT_ to the layer configuration

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,3 +8,5 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "meta-xt-agl-base"
 BBFILE_PATTERN_meta-xt-agl-base = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-xt-agl-base = "6"
+
+LAYERSERIES_COMPAT_meta-xt-agl-base = "rocko sumo thud zeus dunfell"


### PR DESCRIPTION
According to Yocto Mega-Manual:
"Setting LAYERSERIES_COMPAT is required by the Yocto Project
Compatible version 2 standard. The OpenEmbedded build system
produces a warning if the variable is not set for any given layer."

This fixes the following warning during the build:
WARNING: Layer meta-xt-agl-base should set LAYERSERIES_COMPAT_meta-xt-agl-base in its conf/layer.conf file to list the core layer names it is compatible with.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>