### PR TITLE
Only use ADAS meta layer for Kingfisher

### DIFF
--- a/templates/machine/h3ulcb-xt/50_bblayers.conf.inc
+++ b/templates/machine/h3ulcb-xt/50_bblayers.conf.inc
@@ -1,6 +1,5 @@
 BBLAYERS =+ "\
   ${METADIR}/bsp/meta-renesas-rcar-gen3/meta-rcar-gen3 \
-  ${METADIR}/bsp/meta-rcar/meta-rcar-gen3-adas \
   ${METADIR}/meta-xt-images-rcar-gen3 \
   ${METADIR}/meta-xt-agl-base \
   ${METADIR}/meta-aos \

--- a/templates/machine/m3ulcb-xt/50_bblayers.conf.inc
+++ b/templates/machine/m3ulcb-xt/50_bblayers.conf.inc
@@ -1,6 +1,5 @@
 BBLAYERS =+ "\
   ${METADIR}/bsp/meta-renesas-rcar-gen3/meta-rcar-gen3 \
-  ${METADIR}/bsp/meta-rcar/meta-rcar-gen3-adas \
   ${METADIR}/meta-xt-images-rcar-gen3 \
   ${METADIR}/meta-xt-agl-base \
   ${METADIR}/meta-aos \

--- a/templates/machine/salvator-x-h3-4x2g-xt/50_bblayers.conf.inc
+++ b/templates/machine/salvator-x-h3-4x2g-xt/50_bblayers.conf.inc
@@ -1,6 +1,5 @@
 BBLAYERS =+ "\
   ${METADIR}/bsp/meta-renesas-rcar-gen3/meta-rcar-gen3 \
-  ${METADIR}/bsp/meta-rcar/meta-rcar-gen3-adas \
   ${METADIR}/meta-xt-images-rcar-gen3 \
   ${METADIR}/meta-xt-agl-base \
   ${METADIR}/meta-aos \

--- a/templates/machine/salvator-x-h3-xt/50_bblayers.conf.inc
+++ b/templates/machine/salvator-x-h3-xt/50_bblayers.conf.inc
@@ -1,6 +1,5 @@
 BBLAYERS =+ "\
   ${METADIR}/bsp/meta-renesas-rcar-gen3/meta-rcar-gen3 \
-  ${METADIR}/bsp/meta-rcar/meta-rcar-gen3-adas \
   ${METADIR}/meta-xt-images-rcar-gen3 \
   ${METADIR}/meta-xt-agl-base \
   ${METADIR}/meta-aos \

--- a/templates/machine/salvator-x-m3-xt/50_bblayers.conf.inc
+++ b/templates/machine/salvator-x-m3-xt/50_bblayers.conf.inc
@@ -1,6 +1,5 @@
 BBLAYERS =+ "\
   ${METADIR}/bsp/meta-renesas-rcar-gen3/meta-rcar-gen3 \
-  ${METADIR}/bsp/meta-rcar/meta-rcar-gen3-adas \
   ${METADIR}/meta-xt-images-rcar-gen3 \
   ${METADIR}/meta-xt-agl-base \
   ${METADIR}/meta-aos \

--- a/templates/machine/salvator-xs-h3-xt/50_bblayers.conf.inc
+++ b/templates/machine/salvator-xs-h3-xt/50_bblayers.conf.inc
@@ -1,6 +1,5 @@
 BBLAYERS =+ "\
   ${METADIR}/bsp/meta-renesas-rcar-gen3/meta-rcar-gen3 \
-  ${METADIR}/bsp/meta-rcar/meta-rcar-gen3-adas \
   ${METADIR}/meta-xt-images-rcar-gen3 \
   ${METADIR}/meta-xt-agl-base \
   ${METADIR}/meta-aos \

--- a/templates/machine/salvator-xs-m3-2x4g-xt/50_bblayers.conf.inc
+++ b/templates/machine/salvator-xs-m3-2x4g-xt/50_bblayers.conf.inc
@@ -1,6 +1,5 @@
 BBLAYERS =+ "\
   ${METADIR}/bsp/meta-renesas-rcar-gen3/meta-rcar-gen3 \
-  ${METADIR}/bsp/meta-rcar/meta-rcar-gen3-adas \
   ${METADIR}/meta-xt-images-rcar-gen3 \
   ${METADIR}/meta-xt-agl-base \
 "


### PR DESCRIPTION
meta-rcar-gen3-adas is only required while building for Kingfisher,
so remove it for all other machines.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>