### PR TITLE
xen-4.15: replace the name of xen packages.

### DIFF
--- a/inc/agl-image.inc
+++ b/inc/agl-image.inc
@@ -20,9 +20,9 @@ IMAGE_INSTALL_append = " \
     nftables \
     ntpdate-systemd \
     tzdata \
-    xen-base \
-    xen-flask \
-    xen-xenstat \
+    xen-tools \
+    xen-tools-flask \
+    xen-tools-xenstat \
 "
 
 # Configuration for ARM Trusted Firmware


### PR DESCRIPTION
Xen 4.15 does not have the xen-base, xen-flask and xen-xenstat,
instead there are xen-tools, xen-tools-flask and xen-tools-xenstat

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>